### PR TITLE
Only return one row from postgres

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -136,7 +136,11 @@ func (bot *Bot) handlePrivmsg(conn *irc.Conn, line *irc.Line) {
 	}
 
 	// Fire on all cylinders, we're good to go.
-	generatedLine := bot.generateLine()
+	generatedLine, err := bot.generateLine()
+	if err != nil {
+		log.Printf("Couldn't generate line %s\n", err)
+		return
+	}
 	bot.Conn.Privmsg(line.Target(), generatedLine)
 	bot.LastTime = time.Now().Unix()
 }

--- a/database.go
+++ b/database.go
@@ -36,11 +36,14 @@ func (bot *Bot) dialDB() {
 	bot.DB = db
 }
 
-func (bot *Bot) generateLine() string {
+func (bot *Bot) generateLine() (string, error) {
 	var link Link
 	var line []string
 
-	query, _ := bot.DB.Prepare("SELECT prefix, suffix FROM markov ORDER BY RANDOM() LIMIT 1")
+	query, err := bot.DB.Prepare("SELECT prefix, suffix FROM markov ORDER BY RANDOM() LIMIT 1")
+	if err != nil {
+		return "", err
+	}
 	query.QueryRow().Scan(&link.Prefix, &link.Suffix)
 	line = append(line, link.Prefix)
 	line = append(line, link.Suffix)
@@ -60,7 +63,7 @@ func (bot *Bot) generateLine() string {
 		line = append(line, link.Suffix)
 	}
 
-	return strings.Join(line, " ")
+	return strings.Join(line, " "), nil
 }
 
 func (bot *Bot) addLink(link Link) {

--- a/database.go
+++ b/database.go
@@ -40,7 +40,7 @@ func (bot *Bot) generateLine() string {
 	var link Link
 	var line []string
 
-	query, _ := bot.DB.Prepare("SELECT prefix, suffix FROM markov ORDER BY RANDOM()")
+	query, _ := bot.DB.Prepare("SELECT prefix, suffix FROM markov ORDER BY RANDOM() LIMIT 1")
 	query.QueryRow().Scan(&link.Prefix, &link.Suffix)
 	line = append(line, link.Prefix)
 	line = append(line, link.Suffix)

--- a/main.go
+++ b/main.go
@@ -7,8 +7,6 @@ import (
 	"sync"
 )
 
-var quit chan (bool)
-
 type Bot struct {
 	Nickname      string   `json:"nickname"`
 	Username      string   `json:"username"`
@@ -49,5 +47,5 @@ func main() {
 	bot.dial()
 	bot.run()
 
-	<-quit
+	select{}
 }


### PR DESCRIPTION
Since we only use 1 row, we might as well tell postgres to only give us one. This results in queries returning about 5x faster on my table with 3M+ rows.